### PR TITLE
Add device-level IO limit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,30 @@ Enables debug mode, which outputs the full Docker commands that will be run on t
 
 Default: `false`
 
+### `device-read-bps` (optional, array)
+
+Limit read rate from a device (format: `<device-path>:<number>[<unit>]`). Number is a positive integer. Unit can be one of `kb`, `mb`, or `gb`.
+
+Example: `["/dev/sda1:200mb"]`
+
+### `device-read-iops` (optional, array)
+
+Limit read rate (IO per second) from a device (format: `<device-path>:<number>`). Number is a positive integer.
+
+Example: `["/dev/sda1:400"]`
+
+### `device-write-bps` (optional, array)
+
+Limit write rate to a device (format: `<device-path>:<number>[<unit>]`). Number is a positive integer. Unit can be one of `kb`, `mb`, or `gb`.
+
+Example: `["/dev/sda1:200mb"]`
+
+### `device-write-iops` (optional, array)
+
+Limit write rate (IO per second) to a device (format: `<device-path>:<number>`). Number is a positive integer.
+
+Example: `["/dev/sda1:400"]`
+
 ### `entrypoint` (optional, string)
 
 Override the image’s default entrypoint, and defaults the `shell` option to `false`. See the [docker run --entrypoint documentation](https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime) for more details. Set it to `""` (empty string) to disable the default entrypoint for the image, but note that you may need to use this plugin's `command` option instead of the top-level `command` option or set a `shell` instead (depending on the command you want/need to run - see [Issue 138](https://github.com/buildkite-plugins/docker-buildkite-plugin/issues/138) for more information).

--- a/commands/run.sh
+++ b/commands/run.sh
@@ -407,6 +407,34 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS:-}" ]]; then
   args+=("--memory-swappiness=${BUILDKITE_PLUGIN_DOCKER_MEMORY_SWAPPINESS}")
 fi
 
+# Handle setting device read throughput if provided
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_DEVICE_READ_BPS; then
+  for arg in "${result[@]}"; do
+    args+=("--device-read-bps" "$arg")
+  done
+fi
+
+# Handle setting device write throughput if provided
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_DEVICE_WRITE_BPS; then
+  for arg in "${result[@]}"; do
+    args+=("--device-write-bps" "$arg")
+  done
+fi
+
+# Handle setting device read IOPS if provided
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_DEVICE_READ_IOPS; then
+  for arg in "${result[@]}"; do
+    args+=("--device-read-iops" "$arg")
+  done
+fi
+
+# Handle setting device write IOPS if provided
+if plugin_read_list_into_result BUILDKITE_PLUGIN_DOCKER_DEVICE_WRITE_IOPS; then
+  for arg in "${result[@]}"; do
+    args+=("--device-write-iops" "$arg")
+  done
+fi
+
 # Handle entrypoint if set, and default shell to disabled
 if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT+x} ]]; then
   args+=("--entrypoint" "${BUILDKITE_PLUGIN_DOCKER_ENTRYPOINT}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -17,6 +17,14 @@ configuration:
       type: string
     debug:
       type: boolean
+    device-read-bps:
+      type: array
+    device-read-iops:
+      type: array
+    device-write-bps:
+      type: array
+    device-write-iops:
+      type: array
     entrypoint:
       type: string
     environment:


### PR DESCRIPTION
The Docker run options `--device-read-bps`, `--device-read-iops`, `--device-write-bps`, `--device-write-iops` can now be set.